### PR TITLE
Get rid of System.CommandLine garbage

### DIFF
--- a/src/bflat/Program.cs
+++ b/src/bflat/Program.cs
@@ -16,7 +16,9 @@
 
 using System;
 using System.CommandLine;
+using System.CommandLine.Builder;
 using System.CommandLine.Help;
+using System.CommandLine.Parsing;
 using System.Reflection;
 
 class Program
@@ -62,12 +64,17 @@ class Program
             }
         });
 
+        Parser parser = new CommandLineBuilder(root)
+                .UseVersionOption("-v")
+                .UseParseErrorReporting()
+                .Build();
+
 #if DEBUG
-        return root.Invoke(args);
+        return parser.Invoke(args);
 #else
         try
         {
-            return root.Invoke(args);
+            return parser.Invoke(args);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Like I wrote in #32 - "Already regretting the switch to System.CommandLine :("

Apparently, in default configuration System.CommandLine will write to /tmp as part of argument parsing. WTF.