### PR TITLE
Allow manual heap deallocation with zerolib

### DIFF
--- a/src/zerolib/Internal/Startup.Efi.cs
+++ b/src/zerolib/Internal/Startup.Efi.cs
@@ -143,7 +143,7 @@ namespace Internal.Runtime.CompilerHelpers
         private readonly void* pad3;
         private readonly void* pad4;
         public readonly delegate*<int, nint, void**, ulong> AllocatePool;
-        private readonly void* pad6;
+        public readonly delegate*<void*, ulong> FreePool;
         private readonly void* pad7;
         private readonly void* pad8;
         private readonly void* pad9;

--- a/src/zerolib/Internal/Stubs.cs
+++ b/src/zerolib/Internal/Stubs.cs
@@ -131,6 +131,15 @@ assigningNull:
             *dst = r;
         }
 
+        [RuntimeExport("RhSuppressFinalize")]
+        public static unsafe void RhSuppressFinalize(object obj)
+        {
+            fixed (MethodTable** mt = &obj.m_pMethodTable)
+            {
+                FreeObject(mt);
+            }
+        }
+
         static unsafe MethodTable** AllocObject(uint size)
         {
 #if WINDOWS
@@ -147,6 +156,21 @@ assigningNull:
 #endif
 
             return result;
+        }
+
+        static unsafe void FreeObject(MethodTable** mt)
+        {
+#if WINDOWS
+            [DllImport("kernel32")]
+            static extern MethodTable** LocalFree(MethodTable** ptr);
+            LocalFree(mt);
+#elif LINUX
+            [DllImport("libSystem.Native")]
+            static extern void SystemNative_Free(MethodTable** ptr);
+            SystemNative_Free(mt);
+#elif UEFI
+            StartupCodeHelpers.s_efiSystemTable->BootServices->FreePool((void*)mt);
+#endif
         }
     }
 }

--- a/src/zerolib/System/GC.cs
+++ b/src/zerolib/System/GC.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.Runtime.CompilerHelpers;
+
+namespace System
+{
+    public static class GC
+    {
+        public static void SuppressFinalize(object obj)
+        {
+            if (obj != null)
+            {
+                StartupCodeHelpers.RhSuppressFinalize(obj);
+            }
+        }
+    }
+}

--- a/src/zerolib/System/IDisposable.cs
+++ b/src/zerolib/System/IDisposable.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System
+{
+    public interface IDisposable
+    {
+        void Dispose();
+    }
+}


### PR DESCRIPTION
Currently, when using `--stdlib:zero`, all heap-allocated data are memory leaks since there is no GC.

This PR adds the ability to manually free heap-allocated objects using the `GC.SuppressFinalize` method. Why this method?

1. It's a standard method from the dotnet API that takes an `object`.
2. When using the dotnet runtime, calls to `GC.SuppressFinalize` are no-ops unless the type has a finalizer.
3. When implementing the `IDisposable` interface, `GC.SuppressFinalize` is typically called at the end when all managed resources have been released. It makes sense to deallocate the object itself at that point.

Example:

```csharp
using System;

class Work : IDisposable
{
    public string Name { get; set; } = nameof(Work);

    public void Dispose()
    {
        Dispose(true);
        GC.SuppressFinalize(this);
    }

    protected virtual void Dispose(bool disposing)
    {
    }
}

class Program
{
    public static void Main()
    {
        while(true)
        {
            using var x = new Work();
            Console.WriteLine(x.Name);
        }
    }
}
```

It is also possible to have nested objects if the `IDisposable` interface is implemented correctly. Arrays also work, but can't implement `IDisposable`, so they have to be freed by calling `GC.SuppressFinalize` directly.

I haven't tested the Linux and UEFI code. Feel free to edit this PR as needed.